### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,22 @@
+---
+name: Bug
+about: Description of a bug or defect.
+---
+
+<!-- description of the issue, please including any relevant information: version, environment, component, error logs, stack trace, etc -->
+
+
+
+## How to reproduce
+
+1. Description of steps to reproduce the issue.
+
+
+## Expected behavior
+
+<!-- description of what you expected to happen. -->
+
+
+## Actual behavior
+
+<!-- description of what actually happened. -->

--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -1,0 +1,18 @@
+---
+name: User story
+about: Story about a new user feature
+title: ''
+labels: ''
+assignees: ''
+
+---
+## User Story
+
+
+
+## Details / tasks
+
+
+
+## Acceptance Criteria
+- [ ] Something


### PR DESCRIPTION
Hey folks, as we're a distributed team, it's important that we communicate clearly though async channels like GH. I'm seeing too many issues created without much description which makes it very difficult to understand what the task is and how we're defining acceptance. I've created some templates to hopefully encourage people to fill out the issue description. I've tried to base the templates off of issues that I think are well defined but I don't have strong feelings on the format. The goal is to encourage folks to be more descriptive and explicit about the tasks. Please comment if you have other suggestions.